### PR TITLE
Platform: Allow env local to override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # Ignore CTags data
 tags
+
+# ignore local env configuration
+.env.local

--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,12 @@
 require 'dotenv'
+
 require 'config/openssl'
 require 'core_ext/string'
 require 'routemaster/application'
 require 'routemaster/services/scheduler'
 require 'newrelic_rpm' if ENV['NEW_RELIC_LICENSE_KEY']
 
-Dotenv.load!
+Dotenv.load!('.env')
+Dotenv.overload('.env.local') if ENV['RACK_ENV'] == 'development'
+
 run Routemaster::Application

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'dotenv'
-Dotenv.load!('.env.test')
 Dotenv.load!('.env')
+Dotenv.overload('.env.test')
 
 require 'pry'
 require 'pry-remote'


### PR DESCRIPTION
We need to allow .env.local to override .env settings locally when running in RACK_ENV=development.  E.g. to change `ROUTEMASTER_CLIENTS` when running RM for multiple apps locally.

Due to foreman gem requiring dotenv and early loading `.env` automatically, it was necessary to use the Dotenv.overload call to achieve this.  For consistency I also updated the spec_helper to take the same approach.