### PR TITLE
Platform: Allow customising bunny continuation timeout [#84393876]

### DIFF
--- a/routemaster/models/bunny_channel.rb
+++ b/routemaster/models/bunny_channel.rb
@@ -19,13 +19,16 @@ module Routemaster
         @_connection.close if @_connection
         @_connection = nil
       end
-      
+
       private
 
       def _channel
         if @_connection.nil? || @_connection.closed? || @_connection.closing?
           @_channel = nil
-          @_connection = Bunny.new(ENV['ROUTEMASTER_AMQP_URL']).start
+          @_connection = Bunny.new(
+            ENV['ROUTEMASTER_AMQP_URL'],
+            continuation_timeout: continuation_timeout
+          ).start
         end
 
         if @_channel.nil? || @_channel.closed?
@@ -33,6 +36,13 @@ module Routemaster
         end
 
         @_channel
+      end
+
+      def continuation_timeout
+        ENV.fetch(
+          'BUNNY_CONTINUATION_TIMEOUT',
+          Bunny::Session::DEFAULT_CONTINUATION_TIMEOUT
+        ).to_i
       end
     end
   end

--- a/routemaster/models/bunny_channel.rb
+++ b/routemaster/models/bunny_channel.rb
@@ -9,6 +9,13 @@ module Routemaster
 
       def method_missing(method, *args, &block)
         _channel.send(method, *args, &block)
+      rescue Timeout::Error
+        attempts_left ||= 2
+        raise if attempts_left < 1
+
+        attempts_left -= 1
+        disconnect
+        retry
       end
 
       def respond_to?(method, include_all = false)

--- a/spec/models/bunny_channel_spec.rb
+++ b/spec/models/bunny_channel_spec.rb
@@ -1,0 +1,98 @@
+require 'routemaster/models/bunny_channel'
+
+describe Routemaster::Models::BunnyChannel do
+  subject { Routemaster::Models::BunnyChannel.instance }
+
+  let(:channel) { double('Channel', mocked_method: true, closed?: false) }
+  let(:session) do
+    double(
+      'Session',
+      create_channel: channel,
+      closed?: false,
+      closing?: false,
+      close: true
+    )
+  end
+
+  before do
+    allow(subject).to receive(:disconnect)
+    allow(session).to receive(:start).and_return(session)
+    allow(Bunny).to receive(:new).and_return(session)
+
+    # Reset the singleton
+    Singleton.__init__(described_class)
+  end
+
+  after(:all) { Singleton.__init__(described_class) }
+
+  context 'when connection is not establised' do
+    context 'when bunny continuation timeout is not set' do
+      it 'creates a new Bunny session' do
+        expect(Bunny).to receive(:new).with(
+          ENV['ROUTEMASTER_AMQP_URL'],
+          continuation_timeout: Bunny::Session::DEFAULT_CONTINUATION_TIMEOUT
+        ).and_return(session)
+
+        subject.mocked_method
+      end
+    end
+
+    context 'when bunny continuation timeout is set' do
+      it 'creates a new Bunny session' do
+        ENV['BUNNY_CONTINUATION_TIMEOUT'] = '1000'
+
+        expect(Bunny).to receive(:new).with(
+          ENV['ROUTEMASTER_AMQP_URL'],
+          continuation_timeout: 1000
+        ).and_return(session)
+
+        subject.mocked_method
+
+        ENV['BUNNY_CONTINUATION_TIMEOUT'] = nil
+      end
+    end
+  end
+
+  context 'when connection is already established' do
+    before { subject.mocked_method }
+
+    it 'creates a new Bunny session' do
+      expect(Bunny).to_not receive(:new)
+
+      subject.mocked_method
+    end
+  end
+
+  context 'on timeout' do
+    context 'raises error only once' do
+      before do
+        @times_called = 0
+
+        allow(Bunny).to receive(:new) do
+          @times_called += 1
+
+          if @times_called == 1
+            raise Timeout::Error
+          else
+            session
+          end
+        end
+      end
+
+      it 'should disconnect before reconnecting' do
+        expect(subject).to receive(:disconnect).once
+        subject.mocked_method
+      end
+
+      it { expect { subject.mocked_method }.to_not raise_error }
+    end
+
+    context 'after three timeouts' do
+      before do
+        allow(Bunny).to receive(:new).exactly(3).times.and_raise(Timeout::Error)
+      end
+
+      it { expect { subject.mocked_method }.to raise_error(Timeout::Error) }
+    end
+  end
+end


### PR DESCRIPTION
Sometimes we get the below error while trying to get Rabbitmq metrics
```
Feb 18 08:59:05 routemaster-production app/web.17:  E, [2015-02-18T08:59:03.572065 #15] ERROR -- : app error: undefined method `message_count' for #<AMQ::Protocol::Exchange::DeclareOk:0x007f5cb02ef928> (NoMethodError) 
Feb 18 08:59:05 routemaster-production app/web.17:  E, [2015-02-18T08:59:03.572221 #15] ERROR -- : /app/vendor/bundle/ruby/2.1.0/gems/bunny-1.6.3/lib/bunny/queue.rb:304:in `status' 
Feb 18 08:59:05 routemaster-production app/web.17:  E, [2015-02-18T08:59:03.572264 #15] ERROR -- : /app/vendor/bundle/ruby/2.1.0/gems/bunny-1.6.3/lib/bunny/queue.rb:310:in `message_count' 
```

We also get quite a few timeout errors around similar times 
```
Feb 18 00:47:32 routemaster-production app/web.11:  Timeout::Error - execution expired: 
Feb 18 00:47:32 routemaster-production app/web.11:      /app/vendor/bundle/ruby/2.1.0/gems/bunny-1.6.3/lib/bunny/concurrent/continuation_queue.rb:25:in `pop' 
Feb 18 00:47:32 routemaster-production app/web.11:      /app/vendor/bundle/ruby/2.1.0/gems/bunny-1.6.3/lib/bunny/concurrent/continuation_queue.rb:25:in `block in poll'
```

Looking at the Bunny gem code, it seems these both are related. Allow the option to customise the continuation timeout while creating `BunnyChannel` so `Bunny` doesn't just use the default timeout.