### PR TITLE
Rescue and reconnect Bunny::ConnectionClosedError

### DIFF
--- a/routemaster/models/bunny_channel.rb
+++ b/routemaster/models/bunny_channel.rb
@@ -9,7 +9,7 @@ module Routemaster
 
       def method_missing(method, *args, &block)
         _channel.send(method, *args, &block)
-      rescue Timeout::Error
+      rescue Timeout::Error, Bunny::ConnectionClosedError
         attempts_left ||= 2
         raise if attempts_left < 1
 


### PR DESCRIPTION
Handle the error

```
Bunny::ConnectionClosedError
Trying to send frame through a closed connection. Frame is #<AMQ::Protocol::MethodFrame:0x007f51a79e7eb0 @payload="\x002\x00\n\x00\x00Hroutemaster.staging.housetrip_affiliate_523e048ffa06a6442ae37b688b31e7d3\x03\x00\x00\x00\x00", @channel=1>, method class is AMQ::Protocol::Queue::Declare
```