### PR TITLE
Timeout changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 - rabbitmq
 script:
 - bundle exec rspec
+sudo: false
 install:
 - "./rebund/run download"
 - bundle install --path vendor/bundle

--- a/routemaster/services/deliver.rb
+++ b/routemaster/services/deliver.rb
@@ -69,6 +69,11 @@ class Routemaster::Services::Deliver
     @_conn ||= Faraday.new(@subscription.callback) do |c|
       c.adapter Faraday.default_adapter
       c.basic_auth(@subscription.uuid, 'x')
+      if ENV.has_key?('DELIVERY_TIMEOUT')
+        c.options.timeout =
+          c.options.open_timeout =
+            ENV.fetch('DELIVERY_TIMEOUT').to_f
+      end
     end
   end
 end

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -85,7 +85,17 @@ describe Routemaster::Services::Deliver do
           stub_request(:post, callback_auth).to_return(status: 500)
         end
 
-        it 'raises an exception' do
+        it 'raises a CantDeliver exception' do
+          expect { perform }.to raise_error(described_class::CantDeliver)
+        end
+      end
+
+      context "when the callback times out" do
+        before do
+          stub_request(:post, callback_auth).to_timeout
+        end
+
+        it 'raises a CantDeliver exception' do
           expect { perform }.to raise_error(described_class::CantDeliver)
         end
       end
@@ -103,7 +113,7 @@ describe Routemaster::Services::Deliver do
         expect(a_request(:any, callback_auth)).not_to have_been_made
       end
 
-      it 'returns flasy' do
+      it 'returns falsy' do
         expect(perform).to eq(false)
       end
     end


### PR DESCRIPTION
:boom: Catch timeout errors so we can mark the delivery failure.
:clock1030: Allow timeout to be set by an ENV var
:white_check_mark: Closes #53 

//cc @pedrocunha, @mezis 