### PR TITLE
Revert "Timeout changes"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 - rabbitmq
 script:
 - bundle exec rspec
-sudo: false
 install:
 - "./rebund/run download"
 - bundle install --path vendor/bundle

--- a/routemaster/services/deliver.rb
+++ b/routemaster/services/deliver.rb
@@ -34,14 +34,9 @@ class Routemaster::Services::Deliver
     end
 
     # send data
-    response = begin
-      _conn.post do |post|
-        post.headers['Content-Type'] = 'application/json'
-        post.body = data.to_json
-      end
-    rescue Faraday::TimeoutError
-      _log.warn { "timed out delivering #{@buffer.length} events to '#{@subscription.subscriber}'" }
-      raise CantDeliver.new('delivery failure')
+    response = _conn.post do |post|
+      post.headers['Content-Type'] = 'application/json'
+      post.body = data.to_json
     end
 
     if response.success?
@@ -69,11 +64,6 @@ class Routemaster::Services::Deliver
     @_conn ||= Faraday.new(@subscription.callback) do |c|
       c.adapter Faraday.default_adapter
       c.basic_auth(@subscription.uuid, 'x')
-      if ENV.has_key?('DELIVERY_TIMEOUT')
-        c.options.timeout =
-          c.options.open_timeout =
-            ENV.fetch('DELIVERY_TIMEOUT').to_f
-      end
     end
   end
 end

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -85,17 +85,7 @@ describe Routemaster::Services::Deliver do
           stub_request(:post, callback_auth).to_return(status: 500)
         end
 
-        it 'raises a CantDeliver exception' do
-          expect { perform }.to raise_error(described_class::CantDeliver)
-        end
-      end
-
-      context "when the callback times out" do
-        before do
-          stub_request(:post, callback_auth).to_timeout
-        end
-
-        it 'raises a CantDeliver exception' do
+        it 'raises an exception' do
           expect { perform }.to raise_error(described_class::CantDeliver)
         end
       end
@@ -113,7 +103,7 @@ describe Routemaster::Services::Deliver do
         expect(a_request(:any, callback_auth)).not_to have_been_made
       end
 
-      it 'returns falsy' do
+      it 'returns flasy' do
         expect(perform).to eq(false)
       end
     end


### PR DESCRIPTION
:back: Reverts HouseTrip/routemaster#56
:boom: This was causing bunny errors, akin to:
```
2015-09-28T13:12:07.115603+00:00 app[web.1]: { 70357506517960 rufus-scheduler intercepted an error:
2015-09-28T13:12:07.115611+00:00 app[web.1]:   70357506517960   job:
2015-09-28T13:12:07.115621+00:00 app[web.1]:   70357506517960     Rufus::Scheduler::EveryJob "5s" {}
2015-09-28T13:12:07.115623+00:00 app[web.1]:   70357506517960   error:
2015-09-28T13:12:07.115625+00:00 app[web.1]:   70357506517960     70357506517960
2015-09-28T13:12:07.115627+00:00 app[web.1]:   70357506517960     Bunny::ConnectionClosedError
2015-09-28T13:12:07.115630+00:00 app[web.1]:   70357506517960     Trying to send frame through a closed connection. Frame is #<AMQ::Protocol::MethodFrame:0x007ffac45dd7e0 @payload="\x002\x00\n\x00\x00@routemaster...
```