### PR TITLE
Supply: Setup Routemaster Health check, integrate with New Relic [#114856477]

### DIFF
--- a/routemaster/application.rb
+++ b/routemaster/application.rb
@@ -5,6 +5,7 @@ require 'rack/ssl'
 require 'routemaster/middleware/authentication'
 require 'routemaster/controllers/pulse'
 require 'routemaster/controllers/topics'
+require 'routemaster/controllers/health'
 require 'routemaster/controllers/subscription'
 require 'routemaster/mixins/log_exception'
 require 'hirefire-resource' if ENV['AUTOSCALE_WITH'] == 'hirefire'
@@ -20,6 +21,8 @@ class Routemaster::Application < Sinatra::Base
 
   use Rack::SSL
   use HireFire::Middleware if ENV['AUTOSCALE_WITH'] == 'hirefire'
+  use Routemaster::Controllers::Health
+
   use Routemaster::Middleware::Authentication
   use Routemaster::Controllers::Pulse
   use Routemaster::Controllers::Topics

--- a/routemaster/controllers/health.rb
+++ b/routemaster/controllers/health.rb
@@ -1,0 +1,9 @@
+require 'routemaster/controllers'
+require 'sinatra'
+
+class Routemaster::Controllers::Health < Sinatra::Base
+  get /^\/health\/ping(|.json)$/ do
+    content_type :json
+    { pong: Time.now }.to_json
+  end
+end

--- a/spec/controllers/health_spec.rb
+++ b/spec/controllers/health_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'routemaster/controllers/health'
+require 'spec/support/rack_test'
+require 'json'
+
+describe Routemaster::Controllers::Health do
+  let(:app) { described_class }
+  let(:perform) { get '/health/ping' }
+
+  it 'succeeds, responding with pong' do
+    perform
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to match(/pong/)
+  end
+end


### PR DESCRIPTION
Adds a `health/ping(.json)` endpoint that responds with a pong for NR uptime/availability monitoring. Deployed to routemaster-staging1 and tested (see Paw response screenshot).

<img width="522" alt="screen shot 2016-03-03 at 17 13 25" src="https://cloud.githubusercontent.com/assets/2095/13502618/94793590-e163-11e5-9038-6db8ce1e77c4.png">

===

* :rocket: Deployed to http://routemaster-staging1.herokuapp.com
* :warning: **Please don't merge until ALL tests finish running && MASTER IS ALSO GREEN!**

===

Pivotal tracker story [#114856477](https://www.pivotaltracker.com/story/show/114856477) in project *Supply*: